### PR TITLE
Re-allocating neighbour list if it overflows.

### DIFF
--- a/mlff/md/calculator.py
+++ b/mlff/md/calculator.py
@@ -136,7 +136,15 @@ class mlffCalculator(Calculator):
 
         neighbors = self.spatial_partitioning.update_fn(R, self.neighbors)
         if neighbors.overflow:
-            raise RuntimeError('Spatial overflow.')
+            self.neighbors, self.spatial_partitioning = neighbor_list(positions=R,
+                                                                      cell=cell,
+                                                                      cutoff=self.cutoff,
+                                                                      skin=0.,
+                                                                      capacity_multiplier=self.capacity_multiplier)
+            logging.msg('Re-allocating neighbours. ') 
+            neighbors = self.spatial_partitioning.update_fn(R, self.neighbors)
+            assert not neighbors.overflow
+            self.neighbors = neighbors
         else:
             self.neighbors = neighbors
 

--- a/mlff/md/calculator.py
+++ b/mlff/md/calculator.py
@@ -141,7 +141,7 @@ class mlffCalculator(Calculator):
                                                                       cutoff=self.cutoff,
                                                                       skin=0.,
                                                                       capacity_multiplier=self.capacity_multiplier)
-            logging.msg('Re-allocating neighbours. ') 
+            logging.mlff('Re-allocating neighbours. ') 
             neighbors = self.spatial_partitioning.update_fn(R, self.neighbors)
             assert not neighbors.overflow
             self.neighbors = neighbors

--- a/mlff/md/calculator_sparse.py
+++ b/mlff/md/calculator_sparse.py
@@ -276,7 +276,19 @@ class mlffCalculatorSparse(Calculator):
 
         neighbors = self.spatial_partitioning.update_fn(system.R, self.neighbors, new_cell=cell)
         if neighbors.overflow:
-            raise RuntimeError('Spatial overflow.')
+            logging.msg('Re-allocating neighbours. ') 
+            self.neighbors, self.spatial_partitioning = neighbor_list(
+                        positions=system.R,
+                        cell=cell,
+                        cutoff=self.cutoff,
+                        skin=self.skin,
+                        capacity_multiplier=self.capacity_multiplier,
+                        buffer_size_multiplier=self.buffer_size_multiplier,
+                        lr_cutoff=self.lr_cutoff,
+            )
+            neighbors = self.spatial_partitioning.update_fn(system.R, self.neighbors, new_cell=cell)
+            assert not neighbors.overflow
+            self.neighbors = neighbors
         else:
             self.neighbors = neighbors
         if neighbors.cell_list is not None:

--- a/mlff/md/calculator_sparse.py
+++ b/mlff/md/calculator_sparse.py
@@ -276,7 +276,7 @@ class mlffCalculatorSparse(Calculator):
 
         neighbors = self.spatial_partitioning.update_fn(system.R, self.neighbors, new_cell=cell)
         if neighbors.overflow:
-            logging.msg('Re-allocating neighbours. ') 
+            logging.mlff('Re-allocating neighbours. ') 
             self.neighbors, self.spatial_partitioning = neighbor_list(
                         positions=system.R,
                         cell=cell,


### PR DESCRIPTION
Changing code to re-allocate neighbours instead of throwing `RuntimeError('Spatial overflow.')` as per discussion [here](https://github.com/general-molecular-simulations/so3lr/issues/11). 

Changes relative to discussion
1. Changed `print(..)` to `logging.msg('Re-allocating neighbours. ')`
2. Copied code in both `calculator_sparse.py` and `calculator.py` - LMK if that doesn't make any sense. 

```
# before
if neighbors.overflow:
   RuntimeError('Spatial overflow.')
   
# new 
if neighbors.overflow:
  self.neighbors, self.spatial_partitioning = neighbor_list(positions=R,
                                                                      cell=cell,
                                                                      cutoff=self.cutoff,
                                                                      skin=0.,
                                                                      capacity_multiplier=self.capacity_multiplier)
            logging.mlff('Re-allocating neighbours. ') 
            neighbors = self.spatial_partitioning.update_fn(R, self.neighbors)
            assert not neighbors.overflow
            self.neighbors = neighbors
```            